### PR TITLE
Add MUI CSS Baseline to shared components Storybook

### DIFF
--- a/cx-portal-shared-components/.storybook/preview.js
+++ b/cx-portal-shared-components/.storybook/preview.js
@@ -20,10 +20,12 @@
 
 import React from 'react'
 import { SharedThemeProvider } from '../src/components/basic/SharedThemeProvider'
+import { SharedCssBaseline } from '../src/components/basic/SharedCssBaseline'
 
 export const decorators = [
   (Story) => (
     <SharedThemeProvider>
+      <SharedCssBaseline />
       <Story />
     </SharedThemeProvider>
   ),


### PR DESCRIPTION
This adds the MUI CSSBaseline component to Storybook.
I had noticed this was missing there, but it is included in the portal. I think it's quite important that the components inside Storybook also get the CSS Baseline. Otherwise font rendering will be different, and very importantly box-sizing: border-box wouldn't be set by default.
