### PR TITLE
bugfix/app_release_board

### DIFF
--- a/cx-portal/src/features/adminBoard/adminBoardApiSlice.ts
+++ b/cx-portal/src/features/adminBoard/adminBoardApiSlice.ts
@@ -72,7 +72,7 @@ export const apiSlice = createApi({
     }),
     declineRequest: builder.mutation<boolean, string>({
       query: (appId) => ({
-        url: `/api/apps/appreleaseprocess/${appId}/declineApp`,
+        url: `/api/apps/${appId}/declineApp`,
         method: 'PUT',
       }),
     }),


### PR DESCRIPTION
Endpoint for decline app is currently still inside the controller "apps". Till the endpoint is moved to "appreleaseprocess" we need to call the apps endpoint path