### PR TITLE
BugFix - Register daps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Catena-X Portal Frontend.
 
 ### Unreleased
+* Connector
+   * BugFix - Register daps via the auth icon in the connector registration, allows all type of files
 
 ## 1.0.0-RC10
 

--- a/cx-portal/src/components/pages/EdcConnector/AddConnectorOverlay/components/CreateDapsRegistration.tsx
+++ b/cx-portal/src/components/pages/EdcConnector/AddConnectorOverlay/components/CreateDapsRegistration.tsx
@@ -52,7 +52,10 @@ const CreateDapsRegistration = ({
   const [error, setError] = useState(false)
   const [file, setFile] = useState<File>()
   const dropzoneProps = {
-    accept: '*',
+    accept: {
+      'application/x-pem-file': [],
+      'application/x-x509-ca-cert': [],
+    },
   }
 
   return (


### PR DESCRIPTION
Register daps via the auth icon in the connector registration, allows all type of files