### PR TITLE
fix(image-tag_dev): remove branch prefix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,6 @@ jobs:
           application_id: ${{ secrets.ORG_PORTAL_DISPATCH_APPID }}
           application_private_key: ${{ secrets.ORG_PORTAL_DISPATCH_KEY }}
 
-      # The triggered workflow isn't enabled for branch names / github.ref_name containing special characters like '/' for example 'feature/...'
       - name: Trigger workflow
         id: call_action
         env:
@@ -101,5 +100,5 @@ jobs:
             --url https://api.github.com/repos/catenax-ng/tx-portal-cd/actions/workflows/portal-image-update.yml/dispatches \
             --header "authorization: Bearer $TOKEN" \
             --header "Accept: application/vnd.github.v3+json" \
-            --data '{"ref":"helm-environments", "inputs": { "new-image":"${{ github.ref_name }}_${{ env.COMMIT_SHA }}" }}' \
+            --data '{"ref":"helm-environments", "inputs": { "new-image":"${{ env.COMMIT_SHA }}" }}' \
             --fail


### PR DESCRIPTION
I forgot to remove the branch prefix at the dispatch with https://github.com/catenax-ng/tx-portal-frontend/pull/230 and that leads to image not being found on dev environment.