### PR TITLE
bugfix(connector): name does not support special chars and show proper error 

### DIFF
--- a/cx-portal/src/assets/locales/de/main.json
+++ b/cx-portal/src/assets/locales/de/main.json
@@ -447,7 +447,7 @@
             "placeholder": "Connector Name",
             "patternError": {
               "lengthError": "Connector name length should be between 2 and 20.",
-              "otherError": "Connector name can not start with empty space. Allowed special characters are @_:;.-%&?,'!."
+              "otherError": "Connector name can not start with special character or empty space. Allowed special characters are @_:;.-%&?,'!."
             },
             "error": "Connector name is mandatory.",
             "tooltipMsg": "Own selected connector name for verification"

--- a/cx-portal/src/assets/locales/de/main.json
+++ b/cx-portal/src/assets/locales/de/main.json
@@ -445,7 +445,11 @@
           "name": {
             "label": "Name*",
             "placeholder": "Connector Name",
-            "error": "Connector name is mandatory. Length should be between 2 and 20",
+            "patternError": {
+              "lengthError": "Connector name length should be between 2 and 20.",
+              "otherError": "Connector name can not start with empty space. Allowed special characters are @_:;.-%&?,'!."
+            },
+            "error": "Connector name is mandatory.",
             "tooltipMsg": "Own selected connector name for verification"
           },
           "url": {

--- a/cx-portal/src/assets/locales/en/main.json
+++ b/cx-portal/src/assets/locales/en/main.json
@@ -447,7 +447,7 @@
             "placeholder": "Connector Name",
             "patternError": {
               "lengthError": "Connector name length should be between 2 and 20.",
-              "otherError": "Connector name can not start with empty space. Allowed special characters are @_:;.-%&?,'!."
+              "otherError": "Connector name can not start with special character or empty space. Allowed special characters are @_:;.-%&?,'!."
             },
             "error": "Connector name is mandatory.",
             "tooltipMsg": "Own selected connector name for verification"

--- a/cx-portal/src/assets/locales/en/main.json
+++ b/cx-portal/src/assets/locales/en/main.json
@@ -445,7 +445,11 @@
           "name": {
             "label": "Name*",
             "placeholder": "Connector Name",
-            "error": "Connector name is mandatory. Length should be between 2 and 20",
+            "patternError": {
+              "lengthError": "Connector name length should be between 2 and 20.",
+              "otherError": "Connector name can not start with empty space. Allowed special characters are @_:;.-%&?,'!."
+            },
+            "error": "Connector name is mandatory.",
             "tooltipMsg": "Own selected connector name for verification"
           },
           "url": {

--- a/cx-portal/src/components/pages/EdcConnector/AddConnectorOverlay/components/ConnectorInsertForm.tsx
+++ b/cx-portal/src/components/pages/EdcConnector/AddConnectorOverlay/components/ConnectorInsertForm.tsx
@@ -44,6 +44,7 @@ const ConnectorFormInput = ({
   tooltipMsg,
   type,
   dropzoneProps,
+  patternError,
 }: any) => {
   return (
     <>
@@ -107,23 +108,33 @@ const ConnectorFormInput = ({
       ) : (
         <>
           <Controller
-            render={({ field: { onChange, value } }) => (
-              <Input
-                tooltipMessage={tooltipMsg}
-                sx={{
-                  paddingTop: '10px',
-                }}
-                error={!!errors[name]}
-                helperText={helperText}
-                label={label}
-                placeholder={placeholder}
-                onChange={(event) => {
-                  trigger(name)
-                  onChange(event)
-                }}
-                value={value}
-              />
-            )}
+            render={({ field: { onChange, value } }) => {
+              let errortext = helperText
+              if (rules.pattern.test(value)) {
+                errortext = ''
+              } else if ((value.length <= 2 || value.length > 20) && patternError) {
+                errortext = patternError.lengthError
+              } else if (!rules.pattern.test(value) && patternError) {
+                errortext = patternError.otherError
+              }
+              return (
+                <Input
+                  tooltipMessage={tooltipMsg}
+                  sx={{
+                    paddingTop: '10px',
+                  }}
+                  error={!!errors[name]}
+                  helperText={errortext}
+                  label={label}
+                  placeholder={placeholder}
+                  onChange={(event) => {
+                    trigger(name)
+                    onChange(event)
+                  }}
+                  value={value}
+                />
+              )
+            }}
             name={name}
             control={control}
             rules={rules}
@@ -184,6 +195,14 @@ const ConnectorInsertForm = ({
                   helperText: t(
                     'content.edcconnector.modal.insertform.name.error'
                   ),
+                  patternError: {
+                    lengthError: t(
+                      'content.edcconnector.modal.insertform.name.patternError.lengthError'
+                    ),
+                    otherError: t(
+                      'content.edcconnector.modal.insertform.name.patternError.otherError'
+                    ),
+                  },
                   label: t('content.edcconnector.modal.insertform.name.label'),
                   placeholder: t(
                     'content.edcconnector.modal.insertform.name.placeholder'

--- a/cx-portal/src/components/pages/EdcConnector/AddConnectorOverlay/components/ConnectorInsertForm.tsx
+++ b/cx-portal/src/components/pages/EdcConnector/AddConnectorOverlay/components/ConnectorInsertForm.tsx
@@ -112,7 +112,10 @@ const ConnectorFormInput = ({
               let errortext = helperText
               if (rules.pattern.test(value)) {
                 errortext = ''
-              } else if ((value.length <= 2 || value.length > 20) && patternError) {
+              } else if (
+                (value.length <= 2 || value.length > 20) &&
+                patternError
+              ) {
                 errortext = patternError.lengthError
               } else if (!rules.pattern.test(value) && patternError) {
                 errortext = patternError.otherError

--- a/cx-portal/src/types/Patterns.test.ts
+++ b/cx-portal/src/types/Patterns.test.ts
@@ -161,7 +161,7 @@ const TESTDATA = {
   },
   CNAMES: {
     valid: ['word', 'Some word', 'Some@word'],
-    invalid: ['some.word', 'w', '', 'some?@#$word'],
+    invalid: ['some^word', 'w', '', ' some?@#$word'],
   },
   COUNTRY: {
     valid: ['DE'],

--- a/cx-portal/src/types/Patterns.test.ts
+++ b/cx-portal/src/types/Patterns.test.ts
@@ -161,7 +161,7 @@ const TESTDATA = {
   },
   CNAMES: {
     valid: ['word', 'Some word', 'Some@word'],
-    invalid: ['some^word', 'w', '', ' some?@#$word'],
+    invalid: [' someword', 'w', '', ' some??@#$word'],
   },
   COUNTRY: {
     valid: ['DE'],

--- a/cx-portal/src/types/Patterns.ts
+++ b/cx-portal/src/types/Patterns.ts
@@ -80,7 +80,7 @@ export const Patterns = {
     clientSecret: /^.{1,200}$/,
   },
   connectors: {
-    NAME: /^[^-\s][A-Za-z0-9 %&?_,';:!-@]{2,20}$/,
+    NAME: /^[^-\s()'"#@.&](?!.*[%&?,';:!\s-]{2}).{1,19}$/,
     COUNTRY: /^[A-Z]{2}$/,
   },
   CANCEL_INPUT: /^[a-z0-9 ?*%$#@!-](?=)/i,

--- a/cx-portal/src/types/Patterns.ts
+++ b/cx-portal/src/types/Patterns.ts
@@ -80,7 +80,7 @@ export const Patterns = {
     clientSecret: /^.{1,200}$/,
   },
   connectors: {
-    NAME: /^[a-zA-Z0-9 @]{2,20}$/,
+    NAME: /^[^-\s][a-zA-Z0-9 %&?_,';:!-@]{2,20}$/,
     COUNTRY: /^[A-Z]{2}$/,
   },
   CANCEL_INPUT: /^[a-z0-9 ?*%$#@!-](?=)/i,

--- a/cx-portal/src/types/Patterns.ts
+++ b/cx-portal/src/types/Patterns.ts
@@ -80,7 +80,7 @@ export const Patterns = {
     clientSecret: /^.{1,200}$/,
   },
   connectors: {
-    NAME: /^[^-\s][a-zA-Z0-9 %&?_,';:!-@]{2,20}$/,
+    NAME: /^[^-\s][A-Za-z0-9 %&?_,';:!-@]{2,20}$/,
     COUNTRY: /^[A-Z]{2}$/,
   },
   CANCEL_INPUT: /^[a-z0-9 ?*%$#@!-](?=)/i,


### PR DESCRIPTION
connector name field dose not show up appropriate pattern error.
If I enter the company connector name "Test_Felix" and want to create the connector, the name field appears red and it says "Connector Name is Mandatory. Length should be between 2-20". 

I would expect it to say additionally "The connector name should only contain upper and lower case letters, no numbers or special characters"