### PR TITLE
bugfix(dropzone): show appropriate error on upload

### DIFF
--- a/cx-portal/src/components/shared/basic/Dropzone/index.tsx
+++ b/cx-portal/src/components/shared/basic/Dropzone/index.tsx
@@ -139,10 +139,13 @@ export const Dropzone = ({
   }
 
   // TODO: read react-dropzone errorCode instead of message and localize
+  const errorObj = fileRejections?.[0]?.errors?.[0]
+  const fileTypeError =
+    errorObj && fileRejections?.[0]?.errors?.[0].code === 'file-invalid-type'
   const errorMessage =
-    !isDragActive && fileRejections?.[0]?.errors?.[0] && errorText
+    !isDragActive && errorObj && !fileTypeError && errorText
       ? errorText
-      : fileRejections?.[0]?.errors?.[0]?.message
+      : errorObj?.message
 
   const uploadFiles: UploadFile[] = currentFiles.map((file) => ({
     id: file.id,


### PR DESCRIPTION
Reason - I tried to upload a PDF (although only images are allowed). Instead of a file-format warning an error appeared that the size of the file is to big (although it only had a size of 26kbyte)