### PR TITLE
feature(static template) : support language switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
    * ROLE_UPDATE_APP_OFFER and ROLE_UPDATE_CORE_OFFER types added and corresponding contents updated
 * Static templete
    * Two more new templates added
+   * Support language switch
 * ImageComponent
    * Do not hide current on zoom in action
 * Admin board - Service

--- a/cx-portal/src/components/pages/CompanyRoles/index.tsx
+++ b/cx-portal/src/components/pages/CompanyRoles/index.tsx
@@ -25,14 +25,16 @@ import { StageSubNavigation } from 'components/shared/templates/StageSubNavigati
 import CommonService from 'services/CommonService'
 import { getAssetBase } from 'services/EnvironmentService'
 import { StaticTemplateResponsive } from 'components/shared/templates/StaticTemplateResponsive'
+import { useSelector } from 'react-redux'
+import { languageSelector } from 'features/language/slice'
 
 export default function CompanyRoles() {
   const [companyRoles, setCompanyRoles] = useState<any>()
   const [linkArray, setLinkArray] = useState<any>()
   const url = window.location.href
+  const language = useSelector(languageSelector)
   useEffect(() => {
     CommonService.getCompanyRoles((data: any) => {
-      console.log(data)
       setLinkArray([
         {
           index: 1,
@@ -60,7 +62,7 @@ export default function CompanyRoles() {
         setCompanyRoles(data.participant)
       }
     })
-  }, [url])
+  }, [url, language])
 
   return (
     <main className="companyRoles">

--- a/cx-portal/src/components/pages/UseCase/index.tsx
+++ b/cx-portal/src/components/pages/UseCase/index.tsx
@@ -25,10 +25,13 @@ import { useEffect, useState } from 'react'
 import CommonService from 'services/CommonService'
 import { getAssetBase } from 'services/EnvironmentService'
 import { StaticTemplateResponsive } from 'components/shared/templates/StaticTemplateResponsive'
+import { useSelector } from 'react-redux'
+import { languageSelector } from 'features/language/slice'
 
 export default function UseCase() {
   const [useCase, setUseCase] = useState<any>()
   const [linkArray, setLinkArray] = useState<any>()
+  const language = useSelector(languageSelector)
 
   useEffect(() => {
     CommonService.getUseCases((data: any) => {
@@ -56,7 +59,7 @@ export default function UseCase() {
         },
       ])
     })
-  }, [])
+  }, [language])
 
   return (
     <main className="useCase">

--- a/cx-portal/src/components/shared/frame/UserInfo/index.tsx
+++ b/cx-portal/src/components/shared/frame/UserInfo/index.tsx
@@ -34,11 +34,14 @@ import { Link } from 'react-router-dom'
 import './UserInfo.scss'
 import { INTERVAL_CHECK_NOTIFICATIONS } from 'types/Constants'
 import { useGetNotificationMetaQuery } from 'features/notification/apiSlice'
+import { setLanguage } from 'features/language/actions'
+import { useDispatch } from 'react-redux'
 
 export const UserInfo = ({ pages }: { pages: string[] }) => {
   const { t } = useTranslation()
   const [menuOpen, setMenuOpen] = useState(false)
   const avatar = useRef<HTMLDivElement>(null)
+  const dispatch = useDispatch()
   const { data } = useGetNotificationMetaQuery(null, {
     pollingInterval: INTERVAL_CHECK_NOTIFICATIONS,
   })
@@ -99,7 +102,10 @@ export const UserInfo = ({ pages }: { pages: string[] }) => {
         <LanguageSwitch
           current={i18next.language}
           languages={I18nService.supportedLanguages.map((key) => ({ key }))}
-          onChange={changeLanguage}
+          onChange={(key: string) => {
+            dispatch(setLanguage({ language: key }))
+            changeLanguage(key)
+          }}
         />
       </UserMenu>
     </div>

--- a/cx-portal/src/features/language/actions.ts
+++ b/cx-portal/src/features/language/actions.ts
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 Mercedes-Benz Group AG and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import { createAction } from '@reduxjs/toolkit'
+import { name } from './types'
+
+const setLanguage = createAction(
+  `${name}/setLanguage`,
+  function update(Obj: { language: string }) {
+    return {
+      payload: {
+        language: Obj.language,
+      },
+    }
+  }
+)
+
+export { setLanguage }

--- a/cx-portal/src/features/language/slice.ts
+++ b/cx-portal/src/features/language/slice.ts
@@ -1,0 +1,39 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 Mercedes-Benz Group AG and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import { createSlice } from '@reduxjs/toolkit'
+import { RootState } from 'features/store'
+import { initialState, name } from './types'
+
+export const languageSlice = createSlice({
+  name,
+  initialState,
+  reducers: {
+    setLanguage: (state, { payload }) => ({
+      ...state,
+      language: payload.language,
+    }),
+  },
+})
+
+export const languageSelector = (state: RootState): string =>
+  state.languageSlice.language
+
+export default languageSlice

--- a/cx-portal/src/features/language/types.ts
+++ b/cx-portal/src/features/language/types.ts
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 Mercedes-Benz Group AG and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import i18next from 'i18next'
+
+export const name = 'common/language'
+
+export interface LanguageState {
+  language: string
+}
+
+export const initialState: LanguageState = {
+  language: i18next.language,
+}

--- a/cx-portal/src/features/store.ts
+++ b/cx-portal/src/features/store.ts
@@ -61,6 +61,7 @@ import serviceSubscriptionSlice from './serviceSubscription/slice'
 import { apiSlice as serviceSubscriptionApiSlice } from './serviceSubscription/serviceSubscriptionApiSlice'
 import { apiSlice as serviceAdminBoardApiSlice } from './adminBoard/serviceAdminBoardApiSlice'
 import { apiSlice as companyRoleApiSlice } from './companyRoles/companyRoleApiSlice'
+import languageSlice from './language/slice'
 
 export const reducers = {
   admin,
@@ -83,6 +84,7 @@ export const reducers = {
   connector: connectorSlice.reducer,
   notification: notificationSliceDep.reducer,
   error: ErrorSlice.reducer,
+  languageSlice: languageSlice.reducer,
   [idpSlice.reducerPath]: idpSlice.reducer,
   [userSlice.reducerPath]: userSlice.reducer,
   [serviceSlice.reducerPath]: serviceSlice.reducer,


### PR DESCRIPTION
Issue - When switching the language of the portal to german, the user needs to reload the page to get the language switch enabled/visible. Ideally this happens by the portal automatically.