### PR TITLE
User Management - Change roles success/error overlay

### DIFF
--- a/cx-portal/src/components/pages/UserManagement/index.tsx
+++ b/cx-portal/src/components/pages/UserManagement/index.tsx
@@ -68,41 +68,46 @@ export default function UserManagement() {
       <AppArea />
       <ActiveUserTable addUserResponse={isSuccess} />
       {/* success or error dialog/overlay */}
-      <Dialog open={showAlert} sx={{ '.MuiDialog-paper': { maxWidth: '55%' } }}>
-        <DialogContent>
-          <IconButton
-            aria-label="close"
-            onClick={() => alertClose()}
-            sx={{
-              position: 'absolute',
-              right: 16,
-              top: 16,
-              color: '#939393',
-            }}
-          >
-            <CloseIcon />
-          </IconButton>
+      {(isError || isSuccess) && (
+        <Dialog
+          open={showAlert}
+          sx={{ '.MuiDialog-paper': { maxWidth: '55%' } }}
+        >
+          <DialogContent>
+            <IconButton
+              aria-label="close"
+              onClick={() => alertClose()}
+              sx={{
+                position: 'absolute',
+                right: 16,
+                top: 16,
+                color: '#939393',
+              }}
+            >
+              <CloseIcon />
+            </IconButton>
 
-          <Typography mt={7} mb={2} variant="body2" align="center">
-            {isSuccess ? (
-              <CheckCircleOutlineIcon
-                color="success"
-                sx={{ width: 46, height: 46 }}
-              />
-            ) : (
-              <ErrorOutlineIcon
-                color="error"
-                style={{ height: 20, width: 20 }}
-              />
-            )}
-          </Typography>
-          <Typography mb={2} variant="h4" align="center">
-            {isSuccess
-              ? t('content.userAdded.success')
-              : t('content.userAdded.failure')}
-          </Typography>
-        </DialogContent>
-      </Dialog>
+            <Typography mt={7} mb={2} variant="body2" align="center">
+              {isSuccess ? (
+                <CheckCircleOutlineIcon
+                  color="success"
+                  sx={{ width: 46, height: 46 }}
+                />
+              ) : (
+                <ErrorOutlineIcon
+                  color="error"
+                  style={{ height: 20, width: 20 }}
+                />
+              )}
+            </Typography>
+            <Typography mb={2} variant="h4" align="center">
+              {isSuccess
+                ? t('content.userAdded.success')
+                : t('content.userAdded.failure')}
+            </Typography>
+          </DialogContent>
+        </Dialog>
+      )}
     </main>
   )
 }


### PR DESCRIPTION
## Description

On closing success message, an error overlay display for a second. This PR related to that fix.

## Why

Please include an explanation of why this change is necessary as well as relevant motivation and context. List any dependencies that are required for this change.

## Issue

Link to Github issue.

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
